### PR TITLE
fix: Use correct redirect URL after sign-out

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openformation/logto-remix",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "description": "Logto Remix SDK",
   "author": {
     "name": "Open Formation GmbH",

--- a/src/infrastructure/logto/getContext.ts
+++ b/src/infrastructure/logto/getContext.ts
@@ -27,7 +27,7 @@ type GetContextResponse = {
 export const makeGetContext =
   (deps: { storage: LogtoStorage; createClient: CreateLogtoClient }) =>
   async (request: GetContextRequest): Promise<GetContextResponse> => {
-    const { storage, createClient } = deps;
+    const { createClient } = deps;
 
     const client = createClient();
 

--- a/src/useCases/handleSignOut/HandleSignOutController.ts
+++ b/src/useCases/handleSignOut/HandleSignOutController.ts
@@ -53,7 +53,7 @@ export class HandleSignOutController {
       redirectUri: this.redirectUri,
     });
 
-    return redirect(this.redirectUri, {
+    return redirect(result.navigateToUrl, {
       headers: {
         "Set-Cookie": result.cookieHeader,
       },


### PR DESCRIPTION
This PR fixes this problem ...

[Screen_recording_2022-10-19_23.50.18.webm](https://user-images.githubusercontent.com/224910/196988720-77fe94a1-022e-45e5-9a02-80a1f0260a2b.webm)

... by using the correct redirect URL which comes from Logto when calling `signOut`. The expected behavior here is to see the login view in Logto again instead of getting authenticated without entering the credentials.